### PR TITLE
Add multigraph Graph interface and separate genome expression context

### DIFF
--- a/get/src/genomes/edge_edit.rs
+++ b/get/src/genomes/edge_edit.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 
-use super::genome::Genome;
+use super::genome::{EdgeEditContext, Express, Genome};
 use crate::graph::Graph;
 
 /// Edit-script genome: a list of encoded graph-edit opcodes.
@@ -10,11 +10,6 @@ use crate::graph::Graph;
 pub struct EdgeEditGenome(pub Vec<u64>);
 
 impl Genome for EdgeEditGenome {
-    fn express(&self) -> Graph {
-        // TODO: decode each opcode and apply it to a base graph.
-        todo!("edge-edit express")
-    }
-
     fn crossover<R: Rng + ?Sized>(&mut self, _b: &mut Self, _rng: &mut R) {
         // TODO: two-point crossover over the opcode vector.
         todo!("edge-edit crossover")
@@ -29,7 +24,16 @@ impl Genome for EdgeEditGenome {
         self.clone()
     }
 
-    fn print(&self) {
-        println!("EdgeEditGenome({} ops): {:?}", self.0.len(), self.0);
+    fn print(&self) -> String {
+        format!("EdgeEditGenome({} ops): {:?}", self.0.len(), self.0)
+    }
+}
+
+impl Express for EdgeEditGenome {
+    type Context = EdgeEditContext;
+
+    fn express(&self, _context: &Self::Context) -> Graph {
+        // TODO: clone the base graph, decode each opcode, and apply its edit.
+        todo!("edge-edit express")
     }
 }

--- a/get/src/genomes/edge_edit.rs
+++ b/get/src/genomes/edge_edit.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 
-use super::genome::{EdgeEditContext, Express, Genome};
+use super::genome::{EdgeEditContext, Genome};
 use crate::graph::Graph;
 
 /// Edit-script genome: a list of encoded graph-edit opcodes.
@@ -10,6 +10,13 @@ use crate::graph::Graph;
 pub struct EdgeEditGenome(pub Vec<u64>);
 
 impl Genome for EdgeEditGenome {
+    type Context = EdgeEditContext;
+
+    fn express(&self, _context: &Self::Context) -> Graph {
+        // TODO: clone the base graph, decode each opcode, and apply its edit.
+        todo!("edge-edit express")
+    }
+
     fn crossover<R: Rng + ?Sized>(&mut self, _b: &mut Self, _rng: &mut R) {
         // TODO: two-point crossover over the opcode vector.
         todo!("edge-edit crossover")
@@ -26,14 +33,5 @@ impl Genome for EdgeEditGenome {
 
     fn print(&self) -> String {
         format!("EdgeEditGenome({} ops): {:?}", self.0.len(), self.0)
-    }
-}
-
-impl Express for EdgeEditGenome {
-    type Context = EdgeEditContext;
-
-    fn express(&self, _context: &Self::Context) -> Graph {
-        // TODO: clone the base graph, decode each opcode, and apply its edit.
-        todo!("edge-edit express")
     }
 }

--- a/get/src/genomes/genome.rs
+++ b/get/src/genomes/genome.rs
@@ -1,29 +1,41 @@
 use rand::Rng;
+
 use crate::graph::Graph;
 
-/// The variation-operator interface every genome representation implements.
+/// The variation-operator interface implemented by every genome representation.
 ///
-/// `Clone + Send + Sync` lets populations copy individuals and evolve across threads.
+/// `Clone + Send + Sync` allows the GA to copy individuals and evaluate a
+/// population across worker threads.
 pub trait Genome: Clone + Send + Sync {
-    /// Express a genome as a graph. The graph is the phenotype of the genome.
-    fn express(&self) -> Graph;
-
-    /// Recombine two parents in place, producing two children.
-    ///
-    /// `self` and `other` are the parents on entry and the children on return
-    /// (recombined in place). Generic over the RNG so the engine controls the
-    /// reproducible random stream.
+    /// Recombine two parents in place, leaving the resulting children in
+    /// `self` and `other`.
     fn crossover<R: Rng + ?Sized>(&mut self, other: &mut Self, rng: &mut R);
 
-    /// Mutate a genome in place.
-    /// 
-    /// `self` is the genome on entry and the mutated genome on return (mutated in place).
+    /// Mutate this genome in place.
     fn mutate<R: Rng + ?Sized>(&mut self, rng: &mut R);
 
-    /// Create a copy of the genome.
     fn copy(&self) -> Self;
 
-    /// Print a genome in a human-readable format.
-    fn print(&self);
+    /// Return a human-readable description of the genome.
+    fn print(&self) -> String;
 }
 
+/// Converts a genome into its phenotype using run-specific configuration.
+pub trait Express {
+    type Context;
+
+    fn express(&self, context: &Self::Context) -> Graph;
+}
+
+/// Configuration used when an edge-edit genome modifies an initial graph.
+#[derive(Clone, Debug)]
+pub struct EdgeEditContext {
+    pub base_graph: Graph,
+}
+
+/// Configuration used when an SDA genome generates a graph from scratch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SdaContext {
+    pub num_nodes: usize,
+    pub max_steps: usize,
+}

--- a/get/src/genomes/genome.rs
+++ b/get/src/genomes/genome.rs
@@ -7,6 +7,12 @@ use crate::graph::Graph;
 /// `Clone + Send + Sync` allows the GA to copy individuals and evaluate a
 /// population across worker threads.
 pub trait Genome: Clone + Send + Sync {
+    /// Run-level configuration required to express this genome.
+    type Context;
+
+    /// Express this genome as a graph using shared run-level configuration.
+    fn express(&self, context: &Self::Context) -> Graph;
+
     /// Recombine two parents in place, leaving the resulting children in
     /// `self` and `other`.
     fn crossover<R: Rng + ?Sized>(&mut self, other: &mut Self, rng: &mut R);
@@ -18,13 +24,6 @@ pub trait Genome: Clone + Send + Sync {
 
     /// Return a human-readable description of the genome.
     fn print(&self) -> String;
-}
-
-/// Converts a genome into its phenotype using run-specific configuration.
-pub trait Express {
-    type Context;
-
-    fn express(&self, context: &Self::Context) -> Graph;
 }
 
 /// Configuration used when an edge-edit genome modifies an initial graph.

--- a/get/src/genomes/mod.rs
+++ b/get/src/genomes/mod.rs
@@ -3,5 +3,5 @@ pub mod genome;
 pub mod sda;
 
 pub use edge_edit::EdgeEditGenome;
-pub use genome::{EdgeEditContext, Express, Genome, SdaContext};
+pub use genome::{EdgeEditContext, Genome, SdaContext};
 pub use sda::SdaGenome;

--- a/get/src/genomes/mod.rs
+++ b/get/src/genomes/mod.rs
@@ -1,7 +1,7 @@
-pub mod genome;
 pub mod edge_edit;
+pub mod genome;
 pub mod sda;
 
 pub use edge_edit::EdgeEditGenome;
-pub use genome::Genome;
+pub use genome::{EdgeEditContext, Express, Genome, SdaContext};
 pub use sda::SdaGenome;

--- a/get/src/genomes/sda.rs
+++ b/get/src/genomes/sda.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 
-use super::genome::{Express, Genome, SdaContext};
+use super::genome::{Genome, SdaContext};
 use crate::graph::Graph;
 
 /// Self-driving-automaton genome: a finite-state machine whose run emits the
@@ -15,6 +15,13 @@ pub struct SdaGenome {
 }
 
 impl Genome for SdaGenome {
+    type Context = SdaContext;
+
+    fn express(&self, _context: &Self::Context) -> Graph {
+        // TODO: run the automaton and fold its output into a graph.
+        todo!("SDA express")
+    }
+
     /// One-point crossover over states: choose a cut point and swap every state
     /// row (transitions and responses) from the cut onward between the parents.
     fn crossover<R: Rng + ?Sized>(&mut self, other: &mut Self, rng: &mut R) {
@@ -52,14 +59,5 @@ impl Genome for SdaGenome {
             self.init_char,
             self.transitions.len()
         )
-    }
-}
-
-impl Express for SdaGenome {
-    type Context = SdaContext;
-
-    fn express(&self, _context: &Self::Context) -> Graph {
-        // TODO: run the automaton and fold its output into a graph.
-        todo!("SDA express")
     }
 }

--- a/get/src/genomes/sda.rs
+++ b/get/src/genomes/sda.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 
-use super::genome::Genome;
+use super::genome::{Express, Genome, SdaContext};
 use crate::graph::Graph;
 
 /// Self-driving-automaton genome: a finite-state machine whose run emits the
@@ -15,11 +15,6 @@ pub struct SdaGenome {
 }
 
 impl Genome for SdaGenome {
-    fn express(&self) -> Graph {
-        // TODO: run the automaton and fold its output into a graph.
-        todo!("SDA express")
-    }
-
     /// One-point crossover over states: choose a cut point and swap every state
     /// row (transitions and responses) from the cut onward between the parents.
     fn crossover<R: Rng + ?Sized>(&mut self, other: &mut Self, rng: &mut R) {
@@ -51,11 +46,20 @@ impl Genome for SdaGenome {
         self.clone()
     }
 
-    fn print(&self) {
-        println!(
+    fn print(&self) -> String {
+        format!(
             "SdaGenome(init={}, {} states)",
             self.init_char,
             self.transitions.len()
-        );
+        )
+    }
+}
+
+impl Express for SdaGenome {
+    type Context = SdaContext;
+
+    fn express(&self, _context: &Self::Context) -> Graph {
+        // TODO: run the automaton and fold its output into a graph.
+        todo!("SDA express")
     }
 }

--- a/get/src/graph.rs
+++ b/get/src/graph.rs
@@ -1,107 +1,190 @@
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Graph {
     pub num_nodes: usize,
-    /// Weighted adjacency matrix: `adjacency[u][v]` is the weight of edge `u—v`,
-    /// or 0 if there is no edge. Kept symmetric (`[u][v] == [v][u]`) since the
-    /// graph is undirected.
-    pub adjacency: Vec<Vec<u32>>
+    /// Symmetric adjacency matrix whose entries are edge weights.
+    ///
+    /// A zero entry means that no edge exists. A value greater than one
+    /// represents parallel edges between the same pair of vertices.
+    pub adjacency: Vec<Vec<u32>>,
 }
 
 impl Graph {
     /// Create an empty graph with `num_nodes` nodes and no edges.
     pub fn new(num_nodes: usize) -> Self {
-        Graph {
+        Self {
             num_nodes,
-            adjacency: vec![vec![0; num_nodes]; num_nodes]
+            adjacency: vec![vec![0; num_nodes]; num_nodes],
         }
     }
 
-    /// Return true if an edge (nonzero weight) exists between `u` and `v`.
+    /// Return true if at least one edge exists between `u` and `v`.
     pub fn has_edge(&self, u: usize, v: usize) -> bool {
-        return self.weight(u, v) != 0;
+        self.weight(u, v) != 0
     }
 
-    /// Return the weight of edge `u—v`, or 0 if there is no edge
-    /// (or either endpoint is out of range).
+    /// Return the edge multiplicity, or zero for invalid vertices.
     pub fn weight(&self, u: usize, v: usize) -> u32 {
         if u >= self.num_nodes || v >= self.num_nodes {
             return 0;
         }
-        return self.adjacency[u][v];
+        self.adjacency[u][v]
     }
 
-    /// Add every weighted edge in `edges` to the graph.
-    pub fn set_edges(&mut self, edges: &Vec<(usize, usize, u32)>) {
-        for &(u, v, w) in edges {
-            self.add_edge(u, v, w);
-        }
-    }
-
-    /// Set the undirected edge between `u` and `v` to `weight`.
+    /// Set the multiplicity of an undirected edge directly.
     ///
-    /// A `weight` of 0 clears the edge. No-op if either endpoint is out of range
-    /// or `u == v` (self-loops are not allowed).
-    pub fn add_edge(&mut self, u: usize, v: usize, weight: u32) {
+    /// A zero weight clears the edge. Self-loops and invalid vertices are
+    /// ignored.
+    pub fn set_edge(&mut self, u: usize, v: usize, weight: u32) {
         if u >= self.num_nodes || v >= self.num_nodes || u == v {
             return;
         }
+
         self.adjacency[u][v] = weight;
-        self.adjacency[v][u] = weight; // undirected: keep the matrix symmetric
+        self.adjacency[v][u] = weight;
     }
 
-    /// Remove the undirected edge between `u` and `v`, if present.
+    /// Add one parallel edge.
+    pub fn add_edge(&mut self, u: usize, v: usize) {
+        let next = self.weight(u, v) + 1;
+        self.set_edge(u, v, next);
+    }
+
+    /// Remove one parallel edge, if present.
     pub fn remove_edge(&mut self, u: usize, v: usize) {
-        if u >= self.num_nodes || v >= self.num_nodes {
-            return;
+        let current = self.weight(u, v);
+        if current > 0 {
+            self.set_edge(u, v, current - 1);
         }
-        self.adjacency[u][v] = 0;
-        self.adjacency[v][u] = 0;
     }
 
-    /// Return each undirected edge once, as `(u, v, weight)` tuples with `u < v`.
+    /// Remove all parallel edges between `u` and `v`.
+    pub fn clear_edge(&mut self, u: usize, v: usize) {
+        self.set_edge(u, v, 0);
+    }
+
+    /// Set every weighted edge in `edges`.
+    pub fn set_edges(&mut self, edges: &[(usize, usize, u32)]) {
+        for &(u, v, weight) in edges {
+            self.set_edge(u, v, weight);
+        }
+    }
+
+    /// Return each undirected edge once as `(u, v, weight)`.
     pub fn get_edge_list(&self) -> Vec<(usize, usize, u32)> {
         let mut edges = Vec::new();
         for u in 0..self.num_nodes {
-            // start at u + 1 so each undirected edge is emitted exactly once
             for v in (u + 1)..self.num_nodes {
-                let w = self.adjacency[u][v];
-                if w != 0 {
-                    edges.push((u, v, w));
+                let weight = self.adjacency[u][v];
+                if weight != 0 {
+                    edges.push((u, v, weight));
                 }
             }
         }
-        return edges;
+        edges
     }
 
-    /// Return the neighbor of `node` at `index`, wrapping modulo its degree.
-    ///
-    /// Returns `None` if `node` is out of range or has no neighbors.
+    /// Return the distinct neighbor at `index`, wrapping modulo the number of
+    /// distinct neighbors.
     pub fn get_neighbor_at_index(&self, node: usize, index: usize) -> Option<usize> {
         if node >= self.num_nodes {
             return None;
         }
-        let neighbors: Vec<usize> = (0..self.num_nodes)
-            .filter(|&v| self.adjacency[node][v] != 0)
-            .collect();
-        if neighbors.is_empty() {
+
+        let degree = self.degree(node);
+        if degree == 0 {
             return None;
-        } else {
-            return Some(neighbors[index % neighbors.len()]);
         }
+
+        let target = index % degree;
+        let mut seen = 0;
+        for neighbor in 0..self.num_nodes {
+            if self.adjacency[node][neighbor] > 0 {
+                if seen == target {
+                    return Some(neighbor);
+                }
+                seen += 1;
+            }
+        }
+        None
     }
 
-    /// Return the number of neighbors of `node` (0 if out of range).
+    /// Return the number of distinct nodes connected to `node`.
     pub fn degree(&self, node: usize) -> usize {
         if node >= self.num_nodes {
             return 0;
         }
+        self.adjacency[node]
+            .iter()
+            .filter(|&&weight| weight > 0)
+            .count()
+    }
 
-        let mut count = 0;
-        for &w in self.adjacency[node].iter() {
-            if w != 0 {
-                count += 1;
-            }
+    /// Return the total number of incident edge copies, counting parallel
+    /// edges separately.
+    pub fn total_edge_multiplicity(&self, node: usize) -> usize {
+        if node >= self.num_nodes {
+            return 0;
         }
-        return count;
+        self.adjacency[node]
+            .iter()
+            .map(|&weight| weight as usize)
+            .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Graph;
+
+    #[test]
+    fn add_and_remove_change_one_copy() {
+        let mut graph = Graph::new(3);
+
+        graph.add_edge(0, 1);
+        graph.add_edge(0, 1);
+        assert_eq!(graph.weight(0, 1), 2);
+        assert_eq!(graph.weight(1, 0), 2);
+
+        graph.remove_edge(0, 1);
+        assert_eq!(graph.weight(0, 1), 1);
+
+        graph.remove_edge(0, 1);
+        graph.remove_edge(0, 1);
+        assert_eq!(graph.weight(0, 1), 0);
+    }
+
+    #[test]
+    fn graph_supports_arbitrary_multiplicity() {
+        let mut graph = Graph::new(2);
+
+        graph.set_edge(0, 1, 12);
+
+        assert_eq!(graph.weight(0, 1), 12);
+
+        graph.add_edge(0, 1);
+        assert_eq!(graph.weight(0, 1), 13);
+    }
+
+    #[test]
+    fn degree_and_neighbor_selection_use_distinct_neighbors() {
+        let mut graph = Graph::new(4);
+        graph.set_edge(0, 1, 2);
+        graph.set_edge(0, 3, 1);
+
+        assert_eq!(graph.degree(0), 2);
+        assert_eq!(graph.total_edge_multiplicity(0), 3);
+        assert_eq!(graph.get_neighbor_at_index(0, 0), Some(1));
+        assert_eq!(graph.get_neighbor_at_index(0, 1), Some(3));
+        assert_eq!(graph.get_neighbor_at_index(0, 2), Some(1));
+    }
+
+    #[test]
+    fn set_edges_sets_multiplicity_and_preserves_symmetry() {
+        let mut graph = Graph::new(3);
+        graph.set_edges(&[(0, 1, 4), (1, 2, 2)]);
+
+        assert_eq!(graph.get_edge_list(), vec![(0, 1, 4), (1, 2, 2)]);
+        assert_eq!(graph.weight(1, 0), 4);
+        assert_eq!(graph.weight(2, 1), 2);
     }
 }


### PR DESCRIPTION
## Summary

This PR updates the shared graph and genome interfaces used by the edge-edit and SDA frameworks.

## Graph Changes

The adjacency matrix now stores edge multiplicity.

- `set_edge(u, v, weight)` directly sets an edge weight.
- `add_edge(u, v)` adds one parallel edge.
- `remove_edge(u, v)` removes one parallel edge.
- `clear_edge(u, v)` removes all edges between two nodes.
- `degree(node)` counts distinct connected nodes.
- `total_edge_multiplicity(node)` counts parallel edges separately.

## Genome Expression Changes

Graph expression has moved from the `Genome` trait into a separate `Express` trait:

```rust
pub trait Express {
    type Context;

    fn express(&self, context: &Self::Context) -> Graph;
}
```

The context contains run-level configuration. It is stored once by the GA and passed to each genome during expression rather than being stored inside every genome.

```rust
let graph = genome.express(&context);
```

SDA uses `SdaContext`, while edge editing uses `EdgeEditContext`. Rust ensures at compile time that each genome receives the correct context type.

The GA should use the following trait bounds:

```rust
G: Genome + Express
```

## Changes Required for the SDA Implementation

SDA expression should now be implemented separately from `Genome`:

```rust
impl Express for SdaGenome {
    type Context = SdaContext;

    fn express(&self, context: &SdaContext) -> Graph {
        let mut graph = Graph::new(context.num_nodes);

        // Run the SDA and add generated edges to graph.

        graph
    }
}
```

`SdaContext` currently contains:

```rust
pub struct SdaContext {
    pub num_nodes: usize,
    pub max_steps: usize,
}
```

The existing crossover, mutation, and copy methods remain under:

```rust
impl Genome for SdaGenome
```

The `print` method now returns a `String` instead of printing directly.

## Testing

All current tests pass.