### PR TITLE
architecture and method stubs for evolver/lib/fitness and parsing structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ SDA.cpp
 SDA.h
 handoff_transfer_from_c++.md
 handoff_edge_multiplicity_cap_simplification.md
+Cargo.lock

--- a/README.md
+++ b/README.md
@@ -1,14 +1,2 @@
 # GraphEvolutionTool
 The Graph Evolution Tool (GET) generates and refines synthetic network data using a genetic algorithm. Users supply a custom fitness function and application-specific parameters, and GET evolves networks meeting those criteria. GET offers two GA representations, which can be stacked to produce higher-fitness networks.
-
-## Graph multiplicity
-
-GET uses one graph representation for both unweighted graphs and multigraphs.
-`Graph::new(num_nodes)` retains the default maximum multiplicity of five,
-whereas `Graph::unweighted(num_nodes)` enforces weights in `0..=1`.
-`Graph::with_max_edge_multiplicity(num_nodes, cap)` accepts an explicit cap in
-`1..=5`.
-
-SDA callers select the same behavior with `SdaContext::new`,
-`SdaContext::unweighted`, or `SdaContext::with_max_edge_multiplicity`.
-Edge-edit genomes inherit the cap from their base graph.

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,83 @@
+# Example configuration for the Graph Evolution Tool (GET).
+#
+# Copy to `config.toml` and adjust. Fields map onto `get::config::Config`.
+# Commented blocks show the alternative choices for each tagged section.
+
+# --- Shared evolution settings ------------------------------------------------
+
+population_size = 200        # number of individuals per generation
+network_size    = 100        # number of nodes in every expressed graph
+
+# Edge-weight cap. 1 = unweighted (the default if this line is omitted);
+# values up to 5 allow parallel edges / multigraphs.
+max_edge_multiplicity = 1
+
+crossover_rate = 0.9         # probability a selected pair is recombined
+mutation_rate  = 0.2         # probability a child is mutated
+
+# --- Evolution strategy -------------------------------------------------------
+# Generational: replace the whole population each generation, keeping elites.
+
+[evolution]
+type            = "generational"
+num_generations = 500
+elite_count     = 1          # best individuals carried forward (default 1)
+
+# Steady-state alternative: one mate-and-replace event at a time.
+# [evolution]
+# type              = "steady_state"
+# num_mating_events = 100000
+
+# --- Parent selection ---------------------------------------------------------
+
+[selection]
+type            = "tournament"
+tournament_size = 5          # larger = stronger selection pressure
+
+# --- Genome representation ----------------------------------------------------
+# Edge-edit: an edit script applied to a base graph.
+
+[genome]
+type        = "edge_edit"
+gene_length = 256            # number of edit operations per genome
+
+# Relative probability of drawing each edit operation, used when generating and
+# mutating genes. Weights are relative, not percentages: all-equal is the same
+# distribution whether every value is 1.0 or 10.0. Omit the table to leave every
+# operation at 1.0, omit individual lines to leave just those at 1.0, or set an
+# operation to 0.0 to disable it outright. At least one must be positive.
+# [genome.operation_weights]
+# toggle       = 1.0
+# hop          = 1.0
+# add          = 1.0
+# delete       = 1.0
+# swap         = 1.0
+# local_toggle = 1.0
+# local_add    = 1.0
+# local_delete = 1.0
+# null         = 0.0        # e.g. drop the no-op so every gene does something
+
+# SDA alternative: a self-driving automaton that generates a graph from scratch.
+# [genome]
+# type         = "sda"
+# num_states   = 12
+# num_chars    = 2           # for unweighted graphs use max_edge_multiplicity + 1
+# max_resp_len = 4
+# init_state   = 0           # starting state; must be < num_states (default 0)
+
+# --- Fitness objective --------------------------------------------------------
+# SIR epidemic simulation over the expressed graph (native Rust, parallel).
+
+[fitness]
+type           = "sir"
+infection_rate = 0.05        # per-edge transmission probability per timestep
+seed           = 42          # seeds the stochastic simulation
+# patient_zero = 0           # optional: pin the seed node; omit for a random one
+
+# Python fitness alternative: select "python" here, then call
+# `evolver.set_fitness_function(callable)` from Python before `run()`.
+# The callable receives a batch and returns one float per graph (lower = better):
+#   def fitness(batch):  # batch: list[(num_nodes, list[(u, v, weight)])]
+#       return [score(n, edges) for (n, edges) in batch]
+# [fitness]
+# type = "python"

--- a/get/Cargo.toml
+++ b/get/Cargo.toml
@@ -3,6 +3,11 @@ name = "get"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+# cdylib for the importable Python extension module; rlib so `cargo test` can
+# link the crate for the unit tests.
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 # Change pyo3 to include "abi3-py38" (or your min supported version)
 pyo3 = { version = "0.27.2", features = ["extension-module", "abi3-py38"] }
@@ -11,3 +16,4 @@ rayon = "1.8"
 rand = "0.9"
 rand_chacha = "0.9"
 serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"

--- a/get/src/config.rs
+++ b/get/src/config.rs
@@ -1,0 +1,294 @@
+//! Deserializable mirror of `config.toml`.
+//!
+//! These are mostly flat, owned structs rather than the engine's own context
+//! types: [`crate::evolver::SharedEvolutionContext`] is generic over the genome
+//! and carries a non-deserializable `Genome::Context`, so configuration is
+//! parsed into this plain shape and then mapped onto concrete engine types by
+//! the dispatch layer in `lib.rs`.
+//!
+//! Plain data types that carry no such baggage are deserialized directly rather
+//! than mirrored — [`EdgeEditOperationWeights`] is nine `f64`s with a `Default`,
+//! and duplicating it here would buy nothing but a conversion to maintain.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::genomes::EdgeEditOperationWeights;
+
+/// Everything the genetic algorithm needs for a run.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    /// Which evolution strategy to run, and its strategy-specific settings.
+    pub evolution: EvolutionConfig,
+    /// Number of individuals in the population.
+    pub population_size: usize,
+    /// Number of nodes in every expressed graph.
+    pub network_size: usize,
+    /// Edge-weight cap; defaults to 1 (unweighted).
+    #[serde(default = "default_max_edge_multiplicity")]
+    pub max_edge_multiplicity: u32,
+    /// Probability that a selected pair is recombined.
+    pub crossover_rate: f64,
+    /// Probability that a child is mutated.
+    pub mutation_rate: f64,
+    /// Parent-selection strategy.
+    pub selection: SelectionConfig,
+    /// Genome representation and its dimensions.
+    pub genome: GenomeConfig,
+    /// Fitness objective.
+    pub fitness: FitnessConfig,
+}
+
+/// Evolution strategy and its strategy-specific settings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EvolutionConfig {
+    Generational {
+        num_generations: usize,
+        /// Best individuals carried forward each generation; defaults to 1.
+        #[serde(default = "default_elite_count")]
+        elite_count: usize,
+    },
+    SteadyState {
+        num_mating_events: usize,
+    },
+}
+
+/// Parent-selection strategy. Maps onto [`crate::evolver::common::Selection`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SelectionConfig {
+    Tournament { tournament_size: usize },
+}
+
+/// Genome representation and the dimensions used to build random individuals.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum GenomeConfig {
+    EdgeEdit {
+        gene_length: usize,
+        /// Relative probability of each edit operation. Omitted entirely, or
+        /// omitted field by field, every operation defaults to a weight of 1.0.
+        #[serde(default)]
+        operation_weights: EdgeEditOperationWeights,
+    },
+    Sda {
+        num_states: usize,
+        num_chars: usize,
+        max_resp_len: usize,
+        /// State the automaton starts in, before consuming `init_char`'s first
+        /// transition; defaults to 0.
+        ///
+        /// Must be `< num_states`. This is a precondition, not just a default:
+        /// `SdaGenome::run` indexes its response table with this value, so an
+        /// out-of-range `init_state` panics during expression. Whatever maps
+        /// this onto `SdaContext` is responsible for rejecting it at startup.
+        #[serde(default)]
+        init_state: usize,
+    },
+}
+
+/// Fitness objective and its parameters.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FitnessConfig {
+    Sir {
+        infection_rate: f64,
+        #[serde(default)]
+        patient_zero: Option<usize>,
+        seed: u64,
+    },
+}
+
+fn default_max_edge_multiplicity() -> u32 {
+    1
+}
+
+fn default_elite_count() -> usize {
+    1
+}
+
+/// Failure while loading a [`Config`].
+#[derive(Debug)]
+pub enum ConfigError {
+    /// The config file could not be read.
+    Io(std::io::Error),
+    /// The config text was not valid TOML for a [`Config`].
+    Toml(toml::de::Error),
+}
+
+impl Config {
+    /// Parse a [`Config`] from TOML text.
+    pub fn from_toml_str(text: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(text)
+    }
+
+    /// Read and parse a [`Config`] from a TOML file on disk.
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
+        let _ = path.as_ref();
+        todo!("read the file, then delegate to `from_toml_str`")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal valid config; `genome_extra` is appended to the `[genome]`
+    /// table so each test can vary only the operation-weight block.
+    fn config_text(genome_extra: &str) -> String {
+        format!(
+            r#"
+population_size = 200
+network_size    = 100
+crossover_rate  = 0.9
+mutation_rate   = 0.2
+
+[evolution]
+type            = "generational"
+num_generations = 500
+
+[selection]
+type            = "tournament"
+tournament_size = 5
+
+[genome]
+type        = "edge_edit"
+gene_length = 256
+{genome_extra}
+
+[fitness]
+type           = "sir"
+infection_rate = 0.05
+seed           = 42
+"#
+        )
+    }
+
+    fn edge_edit_weights(text: &str) -> EdgeEditOperationWeights {
+        match Config::from_toml_str(text)
+            .expect("config should parse")
+            .genome
+        {
+            GenomeConfig::EdgeEdit {
+                operation_weights, ..
+            } => operation_weights,
+            other => panic!("expected an edge-edit genome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_omitted_operation_weight_table_defaults_every_operation() {
+        assert_eq!(
+            edge_edit_weights(&config_text("")),
+            EdgeEditOperationWeights::default()
+        );
+    }
+
+    #[test]
+    fn a_partial_operation_weight_table_leaves_unlisted_operations_at_one() {
+        let weights = edge_edit_weights(&config_text(
+            "\n[genome.operation_weights]\ntoggle = 2.5\nnull = 0.0\n",
+        ));
+
+        assert_eq!(weights.toggle, 2.5);
+        assert_eq!(weights.null, 0.0);
+        assert_eq!(
+            EdgeEditOperationWeights {
+                toggle: 1.0,
+                null: 1.0,
+                ..weights
+            },
+            EdgeEditOperationWeights::default(),
+            "operations absent from the table should keep the default weight"
+        );
+    }
+
+    #[test]
+    fn a_full_operation_weight_table_round_trips() {
+        let weights = edge_edit_weights(&config_text(
+            "\n[genome.operation_weights]\n\
+             toggle = 1.0\nhop = 2.0\nadd = 3.0\ndelete = 4.0\nswap = 5.0\n\
+             local_toggle = 6.0\nlocal_add = 7.0\nlocal_delete = 8.0\nnull = 9.0\n",
+        ));
+
+        assert_eq!(
+            weights,
+            EdgeEditOperationWeights {
+                toggle: 1.0,
+                hop: 2.0,
+                add: 3.0,
+                delete: 4.0,
+                swap: 5.0,
+                local_toggle: 6.0,
+                local_add: 7.0,
+                local_delete: 8.0,
+                null: 9.0,
+            }
+        );
+    }
+
+    #[test]
+    fn a_misspelled_operation_name_is_an_error_rather_than_a_silent_default() {
+        let error =
+            Config::from_toml_str(&config_text("\n[genome.operation_weights]\ntogle = 2.0\n"))
+                .expect_err("an unknown operation name should not parse");
+
+        assert!(
+            error.to_string().contains("togle"),
+            "the error should name the offending key, got: {error}"
+        );
+    }
+
+    /// Swap the whole `[genome]` table for an SDA one, varying only what the
+    /// test cares about.
+    fn sda_config_text(genome_extra: &str) -> String {
+        config_text("").replace(
+            "type        = \"edge_edit\"\ngene_length = 256",
+            &format!(
+                "type = \"sda\"\nnum_states = 12\nnum_chars = 2\nmax_resp_len = 4{genome_extra}"
+            ),
+        )
+    }
+
+    #[test]
+    fn an_omitted_sda_init_state_defaults_to_zero() {
+        match Config::from_toml_str(&sda_config_text(""))
+            .expect("sda config should parse")
+            .genome
+        {
+            GenomeConfig::Sda { init_state, .. } => assert_eq!(init_state, 0),
+            other => panic!("expected an sda genome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_explicit_sda_init_state_round_trips() {
+        match Config::from_toml_str(&sda_config_text("\ninit_state = 7"))
+            .expect("sda config should parse")
+            .genome
+        {
+            GenomeConfig::Sda {
+                init_state,
+                num_states,
+                ..
+            } => {
+                assert_eq!(init_state, 7);
+                assert_eq!(num_states, 12);
+            }
+            other => panic!("expected an sda genome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_example_config_parses() {
+        let text = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../config.example.toml"
+        ))
+        .expect("config.example.toml should be readable");
+
+        Config::from_toml_str(&text).expect("the shipped example config should parse");
+    }
+}

--- a/get/src/evolver/common.rs
+++ b/get/src/evolver/common.rs
@@ -1,0 +1,78 @@
+//! GA mechanics shared by every evolution strategy.
+//!
+//! These helpers keep selection, population setup, evaluation, and logging in
+//! one place so [`super::generational`] and [`super::steady_state`] don't each
+//! re-implement them.
+
+use rand::Rng;
+
+use super::GenerationStats;
+use crate::fitness::Fitness;
+use crate::genomes::Genome;
+use crate::graph::Graph;
+
+/// Parent-selection strategy.
+///
+/// Kept as an enum so a new mechanism (roulette-wheel, truncation, rank, ...)
+/// is a single extra variant plus one match arm in [`Selection::select`]; the
+/// evolvers just hold a `Selection` and are unaffected. An enum also stays
+/// monomorphized, avoiding `dyn`-dispatch friction with the generic `select`,
+/// and maps directly onto a `config.toml` field.
+pub enum Selection {
+    /// Sample `tournament_size` individuals at random per pick and keep the
+    /// best (lowest fitness).
+    Tournament { tournament_size: usize },
+}
+
+impl Selection {
+    /// Select `count` parents from the scored population. `count` lets a single
+    /// selection round yield more than one individual (e.g. a pair of parents).
+    pub fn select<G, R>(
+        &self,
+        population: &[G],
+        fitnesses: &[f64],
+        count: usize,
+        rng: &mut R,
+    ) -> Vec<G>
+    where
+        G: Genome,
+        R: Rng + ?Sized,
+    {
+        match self {
+            Selection::Tournament { tournament_size } => {
+                let _ = (population, fitnesses, count, tournament_size, rng);
+                todo!("run `count` fitness tournaments and clone the winners")
+            }
+        }
+    }
+}
+
+/// Express every genome against the shared context and score the whole batch,
+/// returning the expressed graphs alongside their fitnesses. Index `i` of both
+/// vectors refers to `population[i]`.
+///
+/// Defers to [`Fitness::evaluate_population`] so native objectives parallelize
+/// over rayon and Python-backed ones batch across the FFI boundary.
+///
+/// The graphs are returned rather than dropped because scoring has to build them
+/// anyway: handing them back costs nothing, and it saves the caller re-expressing
+/// the winner to fill [`super::EvolutionOutcome::best_graph`]. Callers that only
+/// need scores can ignore the first element and let it drop.
+///
+/// Deliberately says nothing about which fitness is *best* — the
+/// lower-is-better convention lives with the caller, so this stays a plain
+/// express-and-score pass.
+pub fn evaluate<G, F>(population: &[G], context: &G::Context, fitness: &F) -> (Vec<Graph>, Vec<f64>)
+where
+    G: Genome,
+    F: Fitness,
+{
+    let _ = (population, context, fitness);
+    todo!("express each genome, score the batch, and return both")
+}
+
+/// Summarize a scored population into one evolution-log row.
+pub fn generation_stats(iteration: usize, fitnesses: &[f64]) -> GenerationStats {
+    let _ = (iteration, fitnesses);
+    todo!("compute best, mean, and standard deviation of `fitnesses`")
+}

--- a/get/src/evolver/generational.rs
+++ b/get/src/evolver/generational.rs
@@ -1,0 +1,55 @@
+//! Generational evolution: the whole population is replaced each generation,
+//! carrying a configurable number of elites forward unchanged.
+
+use rand::Rng;
+
+use super::{
+    Evolver, EvolutionOutcome, GenerationStats, GenerationalContext, SharedEvolutionContext,
+};
+use crate::fitness::Fitness;
+use crate::genomes::Genome;
+
+/// Evolves a population one full generation at a time for a fixed number of
+/// generations.
+pub struct GenerationalEvolver<G: Genome> {
+    shared: SharedEvolutionContext<G>,
+    context: GenerationalContext,
+    population: Vec<G>,
+    history: Vec<GenerationStats>,
+}
+
+impl<G: Genome> GenerationalEvolver<G> {
+    /// Produce the next generation: copy `context.elite_count` elites forward,
+    /// then fill the rest by selecting parents, recombining them by
+    /// `crossover_rate`, and mutating children by `mutation_rate`.
+    fn advance_generation<F, R>(&mut self, fitness: &F, fitnesses: &[f64], rng: &mut R)
+    where
+        F: Fitness,
+        R: Rng + ?Sized,
+    {
+        let _ = (fitness, fitnesses, rng, self.context.elite_count);
+        todo!("carry elites, select parents, recombine and mutate the rest")
+    }
+}
+
+impl<G: Genome> Evolver<G> for GenerationalEvolver<G> {
+    type TypeContext = GenerationalContext;
+
+    fn new(
+        shared: SharedEvolutionContext<G>,
+        type_context: Self::TypeContext,
+        population: Vec<G>,
+    ) -> Self {
+        Self {
+            shared,
+            context: type_context,
+            population,
+            history: Vec::new(),
+        }
+    }
+
+    fn run<F: Fitness>(&mut self, fitness: &F, seed: u64) -> EvolutionOutcome<G> {
+        let _ = (fitness, seed);
+        todo!("seed the RNG and evolve the population for `num_generations`")
+    }
+}

--- a/get/src/evolver/mod.rs
+++ b/get/src/evolver/mod.rs
@@ -1,0 +1,117 @@
+//! The genetic-algorithm engine that drives genomes toward a fitness target.
+//!
+//! [`Evolver`] is the shared interface; [`generational`] and [`steady_state`]
+//! provide the two evolution strategies. Both are generic over the [`Genome`]
+//! representation, so the same engine drives edge-edit and SDA genomes alike.
+
+pub mod common;
+pub mod generational;
+pub mod steady_state;
+
+pub use generational::GenerationalEvolver;
+pub use steady_state::SteadyStateEvolver;
+
+use crate::fitness::Fitness;
+use crate::genomes::Genome;
+use crate::graph::Graph;
+
+use common::Selection;
+
+/// Run-level configuration shared by every evolution strategy.
+///
+/// Field names follow the planning document's "Shared Evolution Context", minus
+/// everything that is already knowable from somewhere else. Each omission is
+/// deliberate, and for the same reason: a second copy of a value can drift out
+/// of step with the original, and nothing would report the disagreement.
+///
+/// - **Population size** is the length of the population handed to
+///   [`Evolver::new`]; evolvers read `self.population.len()`.
+/// - **Network size** and **edge-weight cap** belong to `genome_context` —
+///   `SdaContext` states them directly, `EdgeEditContext` through its
+///   `base_graph`. Read them from there, or from an expressed [`Graph`].
+///
+/// `config.toml` still carries `population_size`, `network_size`, and
+/// `max_edge_multiplicity`; the dispatch layer is what turns them into a sized
+/// population and a genome context, and is the one place they are read.
+pub struct SharedEvolutionContext<G: Genome> {
+    /// Genome-specific expression configuration (e.g. `EdgeEditContext`,
+    /// `SdaContext`) supplied by the associated [`Genome::Context`] type.
+    ///
+    /// Also the authority on graph size and edge-weight cap — see above.
+    pub genome_context: G::Context,
+    /// Probability that a selected pair is recombined.
+    pub crossover_rate: f64,
+    /// Probability that a child is mutated.
+    pub mutation_rate: f64,
+    /// Parent-selection strategy used by both evolution strategies.
+    pub selection: Selection,
+}
+
+/// Extra configuration specific to the generational strategy.
+pub struct GenerationalContext {
+    /// Number of generations to evolve.
+    pub num_generations: usize,
+    /// Number of best individuals copied unchanged into each next generation.
+    /// Configured via `config.toml`; defaults to 1.
+    pub elite_count: usize,
+}
+
+/// Extra configuration specific to the steady-state strategy.
+pub struct SteadyStateContext {
+    /// Number of mate-and-replace events to perform.
+    pub num_mating_events: usize,
+}
+
+/// A single row of the evolution log.
+///
+/// `iteration` counts generations for the generational strategy and mating
+/// events for the steady-state strategy.
+pub struct GenerationStats {
+    pub iteration: usize,
+    pub best_fitness: f64,
+    pub mean_fitness: f64,
+    pub std_dev: f64,
+}
+
+/// The result of an evolution run.
+///
+/// Carries the best genome together with its expressed [`Graph`], so callers
+/// can inspect the genome and use the final network without re-expressing it.
+pub struct EvolutionOutcome<G: Genome> {
+    pub best_genome: G,
+    pub best_graph: Graph,
+    pub best_fitness: f64,
+    pub history: Vec<GenerationStats>,
+}
+
+/// A genetic-algorithm evolution strategy over genome type `G`.
+///
+/// Implementors pair the [`SharedEvolutionContext`] with their own
+/// [`Evolver::TypeContext`] (generations or mating events) and drive a
+/// population against a [`Fitness`] objective.
+pub trait Evolver<G: Genome> {
+    /// Strategy-specific configuration ([`GenerationalContext`] or
+    /// [`SteadyStateContext`]).
+    type TypeContext;
+
+    /// Build an evolver from the shared and strategy-specific contexts and a
+    /// ready-made starting population.
+    ///
+    /// The caller supplies `population` because genome constructors differ per
+    /// representation (and some are fallible), so a generic evolver cannot
+    /// build a `G` itself. Building it in the config-dispatch layer keeps that
+    /// knowledge where it already lives and surfaces invalid dimensions at
+    /// startup rather than mid-run.
+    fn new(
+        shared: SharedEvolutionContext<G>,
+        type_context: Self::TypeContext,
+        population: Vec<G>,
+    ) -> Self
+    where
+        Self: Sized;
+
+    /// Evolve the population against `fitness`, seeding all randomness from
+    /// `seed` for reproducibility, and return the best genome and its
+    /// expressed graph.
+    fn run<F: Fitness>(&mut self, fitness: &F, seed: u64) -> EvolutionOutcome<G>;
+}

--- a/get/src/evolver/steady_state.rs
+++ b/get/src/evolver/steady_state.rs
@@ -1,0 +1,56 @@
+//! Steady-state evolution: each mating event produces a child that replaces the
+//! worst individual, so most of the population persists between events.
+
+use rand::Rng;
+
+use super::{
+    Evolver, EvolutionOutcome, GenerationStats, SharedEvolutionContext, SteadyStateContext,
+};
+use crate::fitness::Fitness;
+use crate::genomes::Genome;
+
+/// Evolves a population one mate-and-replace event at a time for a fixed number
+/// of mating events.
+pub struct SteadyStateEvolver<G: Genome> {
+    shared: SharedEvolutionContext<G>,
+    context: SteadyStateContext,
+    population: Vec<G>,
+    history: Vec<GenerationStats>,
+}
+
+impl<G: Genome> SteadyStateEvolver<G> {
+    /// Perform one mating event: select parents, recombine them by
+    /// `crossover_rate`, mutate the child by `mutation_rate`, and replace the
+    /// worst current individual. The population's best is never discarded, so
+    /// no explicit elitism is needed.
+    fn mating_event<F, R>(&mut self, fitness: &F, fitnesses: &mut [f64], rng: &mut R)
+    where
+        F: Fitness,
+        R: Rng + ?Sized,
+    {
+        let _ = (fitness, fitnesses, rng);
+        todo!("select parents, breed a child, and replace the worst individual")
+    }
+}
+
+impl<G: Genome> Evolver<G> for SteadyStateEvolver<G> {
+    type TypeContext = SteadyStateContext;
+
+    fn new(
+        shared: SharedEvolutionContext<G>,
+        type_context: Self::TypeContext,
+        population: Vec<G>,
+    ) -> Self {
+        Self {
+            shared,
+            context: type_context,
+            population,
+            history: Vec::new(),
+        }
+    }
+
+    fn run<F: Fitness>(&mut self, fitness: &F, seed: u64) -> EvolutionOutcome<G> {
+        let _ = (fitness, seed);
+        todo!("seed the RNG and run `num_mating_events` mating events")
+    }
+}

--- a/get/src/fitness.rs
+++ b/get/src/fitness.rs
@@ -1,0 +1,62 @@
+use rayon::prelude::*;
+
+use crate::graph::Graph;
+
+/// An objective the genetic algorithm optimizes over expressed graphs.
+///
+/// Convention: **lower is better** — a returned value is treated as a cost or
+/// error, matching the reference implementation's MMD scoring. Objectives that
+/// are naturally maximized (for example, "maximize epidemic spread") should
+/// return a negated or inverted value so the engine's minimization still holds.
+///
+/// The `Send + Sync` bound lets [`Fitness::evaluate_population`] score a whole
+/// generation across rayon worker threads.
+pub trait Fitness: Send + Sync {
+    /// Score a single expressed graph.
+    fn evaluate(&self, graph: &Graph) -> f64;
+
+    /// Score an entire generation of expressed graphs.
+    ///
+    /// The default fans [`Fitness::evaluate`] out across rayon, which is ideal
+    /// for native Rust objectives. A Python-backed adapter overrides this to
+    /// acquire the GIL once per generation and vectorize the whole batch,
+    /// instead of paying the FFI/GIL cost once per individual.
+    fn evaluate_population(&self, graphs: &[Graph]) -> Vec<f64> {
+        graphs.par_iter().map(|graph| self.evaluate(graph)).collect()
+    }
+}
+
+/// Native fitness driven by an epidemic simulation over the expressed graph.
+///
+/// The model is SIR with a one-timestep infectious period. When a susceptible
+/// node is infected during a step, it spends the *following* step in the
+/// infected state — that is when it can transmit to each of its still-
+/// susceptible neighbors, with probability [`SirFitness::infection_rate`] per
+/// edge — and it then moves to recovered/removed and never infects again. So
+/// each node is infectious for exactly one step, one step after it is infected.
+/// A single node seeds the outbreak, which runs until no infected nodes remain.
+/// Quantities such as epidemic length or total infected are measured from that
+/// completed run.
+pub struct SirFitness {
+    /// Per-contact probability of transmission along an edge in one timestep.
+    pub infection_rate: f64,
+    /// Which node seeds the outbreak; `None` selects one at random.
+    pub patient_zero: Option<usize>,
+    /// Seed for the stochastic simulation, so scoring is reproducible.
+    pub seed: u64,
+}
+
+impl SirFitness {
+    /// Build an SIR fitness from its simulation parameters.
+    pub fn new(infection_rate: f64, patient_zero: Option<usize>, seed: u64) -> Self {
+        let _ = (infection_rate, patient_zero, seed);
+        todo!("store SIR simulation parameters")
+    }
+}
+
+impl Fitness for SirFitness {
+    fn evaluate(&self, graph: &Graph) -> f64 {
+        let _ = graph;
+        todo!("run the SIR epidemic to completion over `graph` and return a cost")
+    }
+}

--- a/get/src/genomes/edge_edit.rs
+++ b/get/src/genomes/edge_edit.rs
@@ -1,6 +1,9 @@
+use std::sync::{Arc, OnceLock};
+
 use rand::Rng;
 use rand::distr::Distribution;
 use rand::distr::weighted::WeightedIndex;
+use serde::Deserialize;
 
 use super::genome::{EdgeEditContext, Genome};
 use crate::graph::Graph;
@@ -15,10 +18,14 @@ const OPCODE_MASK: u64 = 0xF;
 
 /// Relative probabilities for generating each edge-edit operation.
 ///
-/// The default gives all nine operations equal probability. These values are
-/// kept with the genome because the shared [`Genome::mutate`] interface only
-/// supplies a random-number generator.
-#[derive(Clone, Copy, Debug, PartialEq)]
+/// The default gives all nine operations equal probability. Set via
+/// `[genome.operation_weights]` in `config.toml`; any field omitted there falls
+/// back to that default, and a weight of `0.0` disables its operation outright.
+///
+/// Validated and compiled into a sampler by [`EdgeEditOperators`], which the
+/// population then shares.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct EdgeEditOperationWeights {
     pub toggle: f64,
     pub hop: f64,
@@ -60,10 +67,6 @@ impl EdgeEditOperationWeights {
             self.null,
         ]
     }
-
-    fn distribution(&self) -> WeightedIndex<f64> {
-        WeightedIndex::new(self.values()).expect("edge-edit weights are validated at construction")
-    }
 }
 
 impl Default for EdgeEditOperationWeights {
@@ -82,6 +85,47 @@ impl Default for EdgeEditOperationWeights {
     }
 }
 
+/// A validated operation mix together with its prebuilt sampler.
+///
+/// Built once per run and shared across the whole population behind an `Arc`:
+/// the [`WeightedIndex`] is constructed once rather than on every mutation, and
+/// each individual carries a pointer instead of its own copy of the weights.
+///
+/// `weights` is retained alongside the sampler purely so the type stays
+/// readable in `Debug` output and comparable in tests; nothing samples from it.
+#[derive(Debug, PartialEq)]
+pub struct EdgeEditOperators {
+    weights: EdgeEditOperationWeights,
+    distribution: WeightedIndex<f64>,
+}
+
+impl EdgeEditOperators {
+    /// Validate `weights` and compile them into a sampler, so weight errors
+    /// surface here — at startup, from config — rather than mid-run.
+    pub fn new(weights: EdgeEditOperationWeights) -> Result<Arc<Self>, &'static str> {
+        weights.validate()?;
+        let distribution =
+            WeightedIndex::new(weights.values()).expect("weights are validated immediately above");
+        Ok(Arc::new(Self {
+            weights,
+            distribution,
+        }))
+    }
+
+    /// The mix that draws every operation with equal probability.
+    ///
+    /// Cached, so the weight-agnostic constructors ([`EdgeEditGenome::new`] and
+    /// [`EdgeEditGenome::random`]) share one instance rather than handing every
+    /// individual its own — which would reintroduce exactly the per-genome copy
+    /// this type exists to eliminate.
+    pub fn uniform() -> Arc<Self> {
+        static UNIFORM: OnceLock<Arc<EdgeEditOperators>> = OnceLock::new();
+        Arc::clone(UNIFORM.get_or_init(|| {
+            Self::new(EdgeEditOperationWeights::default()).expect("equal weights are valid")
+        }))
+    }
+}
+
 /// Edit-script genome: a list of encoded graph-edit operations.
 ///
 /// Each gene stores its opcode in the low four bits and a random 32-bit payload
@@ -90,56 +134,39 @@ impl Default for EdgeEditOperationWeights {
 #[derive(Clone, Debug, PartialEq)]
 pub struct EdgeEditGenome {
     pub genes: Vec<u64>,
-    operation_weights: EdgeEditOperationWeights,
+    operators: Arc<EdgeEditOperators>,
 }
 
 impl EdgeEditGenome {
     /// Construct a genome from encoded genes using equal operation weights.
     pub fn new(genes: Vec<u64>) -> Self {
-        Self {
-            genes,
-            operation_weights: EdgeEditOperationWeights::default(),
-        }
+        Self::new_with_operators(genes, EdgeEditOperators::uniform())
     }
 
-    /// Construct a genome from encoded genes and validated operation weights.
-    pub fn new_with_operation_weights(
-        genes: Vec<u64>,
-        operation_weights: EdgeEditOperationWeights,
-    ) -> Result<Self, &'static str> {
-        operation_weights.validate()?;
-        Ok(Self {
-            genes,
-            operation_weights,
-        })
+    /// Construct a genome from encoded genes and a shared operation mix.
+    pub fn new_with_operators(genes: Vec<u64>, operators: Arc<EdgeEditOperators>) -> Self {
+        Self { genes, operators }
     }
 
     /// Generate a random genome using equal operation weights.
     pub fn random<R: Rng + ?Sized>(length: usize, rng: &mut R) -> Self {
-        Self::random_with_operation_weights(length, EdgeEditOperationWeights::default(), rng)
-            .expect("equal edge-edit weights are valid")
+        Self::random_with_operators(length, EdgeEditOperators::uniform(), rng)
     }
 
-    /// Generate a random genome using validated operation weights.
-    pub fn random_with_operation_weights<R: Rng + ?Sized>(
+    /// Generate a random genome drawing opcodes from a shared operation mix.
+    ///
+    /// Infallible: the mix was validated when [`EdgeEditOperators::new`] built
+    /// it, so a whole population can be minted without per-individual error
+    /// handling.
+    pub fn random_with_operators<R: Rng + ?Sized>(
         length: usize,
-        operation_weights: EdgeEditOperationWeights,
+        operators: Arc<EdgeEditOperators>,
         rng: &mut R,
-    ) -> Result<Self, &'static str> {
-        operation_weights.validate()?;
-        let distribution = operation_weights.distribution();
+    ) -> Self {
         let genes = (0..length)
-            .map(|_| Self::generate_gene(rng, &distribution))
+            .map(|_| Self::generate_gene(rng, &operators.distribution))
             .collect();
-        Ok(Self {
-            genes,
-            operation_weights,
-        })
-    }
-
-    /// Return the operation weights used by random generation and mutation.
-    pub fn operation_weights(&self) -> EdgeEditOperationWeights {
-        self.operation_weights
+        Self { genes, operators }
     }
 
     fn generate_gene<R: Rng + ?Sized>(rng: &mut R, distribution: &WeightedIndex<f64>) -> u64 {
@@ -202,20 +229,14 @@ impl Genome for EdgeEditGenome {
 
         let max_changes = self.genes.len().min(MAX_MUTATIONS);
         let change_count = rng.random_range(1..=max_changes);
-        let distribution = self.operation_weights.distribution();
 
-        // Partially shuffle the indices so every selected gene is unique.
-        let mut indices: Vec<usize> = (0..self.genes.len()).collect();
-        for selection in 0..change_count {
-            let swap_with = rng.random_range(selection..indices.len());
-            indices.swap(selection, swap_with);
-            let gene_index = indices[selection];
-            self.genes[gene_index] = Self::generate_gene(rng, &distribution);
+        // Indices are drawn independently, so the same gene can be selected
+        // twice; that is harmless, since each selection overwrites it with a
+        // fresh random gene either way.
+        for _ in 0..change_count {
+            let gene_index = rng.random_range(0..self.genes.len());
+            self.genes[gene_index] = Self::generate_gene(rng, &self.operators.distribution);
         }
-    }
-
-    fn copy(&self) -> Self {
-        self.clone()
     }
 
     fn print(&self) -> String {
@@ -307,21 +328,22 @@ mod tests {
     #[test]
     fn weighted_random_generation_can_force_an_opcode() {
         let mut rng = StdRng::seed_from_u64(7);
-        let genome =
-            EdgeEditGenome::random_with_operation_weights(32, weights_for_add(), &mut rng).unwrap();
+        let operators = EdgeEditOperators::new(weights_for_add()).unwrap();
+        let genome = EdgeEditGenome::random_with_operators(32, operators, &mut rng);
 
         assert!(genome.genes.iter().all(|gene| gene & OPCODE_MASK == 2));
-        assert_eq!(genome.operation_weights(), weights_for_add());
+        assert_eq!(genome.operators.weights, weights_for_add());
     }
 
     #[test]
     fn random_gene_packing_matches_graph_refiner_exactly() {
-        let distribution = EdgeEditOperationWeights::default().distribution();
+        let operators = EdgeEditOperators::uniform();
+        let distribution = &operators.distribution;
         let mut actual_rng = StdRng::seed_from_u64(29);
         let mut reference_rng = StdRng::seed_from_u64(29);
 
         for _ in 0..64 {
-            let actual = EdgeEditGenome::generate_gene(&mut actual_rng, &distribution);
+            let actual = EdgeEditGenome::generate_gene(&mut actual_rng, distribution);
             let opcode = distribution.sample(&mut reference_rng) as u64;
             let payload = reference_rng.random::<u32>() as u64;
             let expected = (payload << 4) | opcode;
@@ -391,19 +413,13 @@ mod tests {
             base_graph: Graph::new(0, 5),
         };
         let invalid = EdgeEditGenome::new(vec![15]);
-        assert_eq!(
-            invalid.express(&empty_context),
-            Graph::new(0, 5)
-        );
+        assert_eq!(invalid.express(&empty_context), Graph::new(0, 5));
 
         let one_node_context = EdgeEditContext {
             base_graph: Graph::new(1, 5),
         };
         let add_self = EdgeEditGenome::new(vec![encode_gene(2, [0, 0, 0, 0], 1)]);
-        assert_eq!(
-            add_self.express(&one_node_context),
-            Graph::new(1, 5)
-        );
+        assert_eq!(add_self.express(&one_node_context), Graph::new(1, 5));
 
         let mut base_graph = Graph::new(2, 5);
         base_graph.add_edge(0, 1);
@@ -417,12 +433,13 @@ mod tests {
     #[test]
     fn crossover_swaps_only_a_nonempty_shared_segment() {
         let mut left = EdgeEditGenome::new(vec![0, 1, 2, 3, 4]);
-        let mut right =
-            EdgeEditGenome::new_with_operation_weights(vec![10, 11, 12], weights_for_add())
-                .unwrap();
+        let mut right = EdgeEditGenome::new_with_operators(
+            vec![10, 11, 12],
+            EdgeEditOperators::new(weights_for_add()).unwrap(),
+        );
         let left_tail = left.genes[3..].to_vec();
-        let left_weights = left.operation_weights();
-        let right_weights = right.operation_weights();
+        let left_weights = left.operators.weights;
+        let right_weights = right.operators.weights;
         let mut rng = StdRng::seed_from_u64(11);
 
         left.crossover(&mut right, &mut rng);
@@ -441,14 +458,16 @@ mod tests {
                         && right.genes[index] == index as u64)
             );
         }
-        assert_eq!(left.operation_weights(), left_weights);
-        assert_eq!(right.operation_weights(), right_weights);
+        assert_eq!(left.operators.weights, left_weights);
+        assert_eq!(right.operators.weights, right_weights);
     }
 
     #[test]
-    fn mutation_replaces_between_one_and_four_unique_genes() {
-        let mut genome =
-            EdgeEditGenome::new_with_operation_weights(vec![8; 10], weights_for_delete()).unwrap();
+    fn mutation_replaces_at_most_four_genes_using_the_shared_mix() {
+        let mut genome = EdgeEditGenome::new_with_operators(
+            vec![8; 10],
+            EdgeEditOperators::new(weights_for_delete()).unwrap(),
+        );
         let mut rng = StdRng::seed_from_u64(19);
 
         genome.mutate(&mut rng);
@@ -469,9 +488,67 @@ mod tests {
     }
 
     #[test]
-    fn copy_and_print_include_the_complete_genome() {
+    fn operators_reject_weights_that_cannot_form_a_distribution() {
+        let all_zero = EdgeEditOperationWeights {
+            add: 0.0,
+            ..weights_for_add()
+        };
+        assert_eq!(
+            EdgeEditOperators::new(all_zero).unwrap_err(),
+            "at least one operation weight must be positive"
+        );
+
+        let not_finite = EdgeEditOperationWeights {
+            toggle: f64::NAN,
+            ..EdgeEditOperationWeights::default()
+        };
+        assert_eq!(
+            EdgeEditOperators::new(not_finite).unwrap_err(),
+            "operation weights must be finite and non-negative"
+        );
+    }
+
+    #[test]
+    fn the_uniform_mix_is_shared_rather_than_rebuilt_per_call() {
+        // `EdgeEditGenome::new`/`random` route through `uniform()`, so a
+        // per-call rebuild would hand every individual its own WeightedIndex.
+        assert!(Arc::ptr_eq(
+            &EdgeEditOperators::uniform(),
+            &EdgeEditOperators::uniform()
+        ));
+
+        let mut rng = StdRng::seed_from_u64(31);
+        let first = EdgeEditGenome::random(4, &mut rng);
+        let second = EdgeEditGenome::random(4, &mut rng);
+        assert!(Arc::ptr_eq(&first.operators, &second.operators));
+    }
+
+    #[test]
+    fn a_zero_weighted_operation_is_never_generated_or_mutated_in() {
+        // `weights_for_delete` leaves only opcode 3 with a positive weight.
+        let operators = EdgeEditOperators::new(weights_for_delete()).unwrap();
+        let mut rng = StdRng::seed_from_u64(37);
+
+        let mut genome = EdgeEditGenome::random_with_operators(64, operators, &mut rng);
+        assert!(genome.genes.iter().all(|gene| gene & OPCODE_MASK == 3));
+
+        for _ in 0..200 {
+            genome.mutate(&mut rng);
+        }
+        assert!(genome.genes.iter().all(|gene| gene & OPCODE_MASK == 3));
+    }
+
+    #[test]
+    fn the_genome_stays_shareable_across_evaluation_threads() {
+        // `Genome: Clone + Send + Sync` is what lets rayon score a population;
+        // the `Arc<EdgeEditOperators>` field must not break it.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<EdgeEditGenome>();
+    }
+
+    #[test]
+    fn print_includes_the_complete_genome() {
         let genome = EdgeEditGenome::new(vec![1, 2, 3]);
-        assert_eq!(genome.copy(), genome);
         assert_eq!(genome.print(), "EdgeEditGenome(3 ops): [1, 2, 3]");
     }
 }

--- a/get/src/genomes/genome.rs
+++ b/get/src/genomes/genome.rs
@@ -8,7 +8,12 @@ use crate::graph::Graph;
 /// population across worker threads.
 pub trait Genome: Clone + Send + Sync {
     /// Run-level configuration required to express this genome.
-    type Context;
+    ///
+    /// `Send + Sync` is required because `evolver::common::evaluate` expresses a
+    /// whole population in parallel over rayon, sharing one `&Self::Context`
+    /// across worker threads. Without the bound that parallel expression does
+    /// not compile.
+    type Context: Send + Sync;
 
     /// Express this genome as a graph using shared run-level configuration.
     fn express(&self, context: &Self::Context) -> Graph;
@@ -19,8 +24,6 @@ pub trait Genome: Clone + Send + Sync {
 
     /// Mutate this genome in place.
     fn mutate<R: Rng + ?Sized>(&mut self, rng: &mut R);
-
-    fn copy(&self) -> Self;
 
     /// Return a human-readable description of the genome.
     fn print(&self) -> String;

--- a/get/src/genomes/sda.rs
+++ b/get/src/genomes/sda.rs
@@ -239,10 +239,6 @@ impl Genome for SdaGenome {
         }
     }
 
-    fn copy(&self) -> Self {
-        self.clone()
-    }
-
     /// Dump `init_char` followed by one line per `state + char -> target
     /// [ response ]`. `init_state` isn't included since it lives on
     /// `SdaContext`, not the genome, and `print` has no context parameter to
@@ -396,7 +392,6 @@ mod tests {
     #[test]
     fn equality_compares_every_field() {
         let base = small_genome();
-        assert_eq!(base.copy(), base);
 
         let mut different_init_char = base.clone();
         different_init_char.init_char = 1;

--- a/get/src/lib.rs
+++ b/get/src/lib.rs
@@ -1,2 +1,68 @@
+pub mod config;
+pub mod evolver;
+pub mod fitness;
 pub mod genomes;
 pub mod graph;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::config::Config;
+
+/// Python-facing entry point to the graph-evolution engine.
+///
+/// Constructed from a `config.toml` path; [`GraphEvolver::run`] dispatches on
+/// the configured evolution strategy, genome representation, and fitness
+/// objective, then returns the best graph found.
+#[pyclass]
+pub struct GraphEvolver {
+    config: Config,
+    best_fitness: Option<f64>,
+}
+
+#[pymethods]
+impl GraphEvolver {
+    /// Load configuration from a `config.toml` file.
+    #[new]
+    fn new(config_path: String) -> PyResult<Self> {
+        let config = Config::from_path(&config_path)
+            .map_err(|err| PyValueError::new_err(format!("failed to load config: {err:?}")))?;
+        Ok(Self {
+            config,
+            best_fitness: None,
+        })
+    }
+
+    /// Evolve a population and return the best graph as a weighted edge list
+    /// `(u, v, multiplicity)`.
+    fn run(&mut self, seed: u64) -> PyResult<Vec<(usize, usize, u32)>> {
+        let _ = (seed, &self.config, &mut self.best_fitness);
+        todo!(
+            "dispatch on config (evolution x genome x fitness), run the evolver, \
+             cache best_fitness, and return the best graph's edge list"
+        )
+    }
+
+    /// Best fitness found so far, or infinity before any run completes.
+    fn best_fitness(&self) -> f64 {
+        self.best_fitness.unwrap_or(f64::INFINITY)
+    }
+
+    /// Write the per-iteration evolution log to `filename` as CSV.
+    fn save_logs(&self, filename: &str) -> PyResult<()> {
+        let _ = filename;
+        todo!("write the run history to `filename`")
+    }
+
+    /// Write the best individual and its graph to `filename`.
+    fn save_results(&self, filename: &str) -> PyResult<()> {
+        let _ = filename;
+        todo!("write the best genome and edge list to `filename`")
+    }
+}
+
+#[pymodule]
+fn get(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<GraphEvolver>()?;
+    Ok(())
+}


### PR DESCRIPTION
## What this PR adds

The trait skeleton and configuration layer for the genetic-algorithm engine, plus
the two genome representations.
**Every unfinished body is a`todo!()`**

- The crate compiles and `cargo test` is green, so the stubs can be
filled one at a time without the tree ever being broken.

| Layer | State |
|---|---|
| `graph.rs`, `genomes/` (edge-edit, SDA, operations) | complete, tested |
| `config.rs` — schema + TOML parsing | complete, tested |
| `evolver/` — `Evolver`, `Selection`, shared mechanics | signatures only |
| `fitness.rs` — `Fitness` trait, `SirFitness` | trait done, SIR stubbed |
| `lib.rs` — `GraphEvolver` pyclass, dispatch | signatures only |

## The thinking behind the stubs
**A three-stage pipeline, each stage swappable.**
`Genome --express--> Graph --Fitness--> f64`. The engine never learns which representation produced a graph or where a score came from, so a new representation or objective is one trait impl and one dispatch arm.

**Lower is always better.**
 One convention across every `Fitness` impl, so selection, elitism, and steady-state's replace-worst all agree without each re-deriving direction. Naturally-maximised objectives negate.

**Expression configuration lives with the representation, not the engine.**
`Genome` has an associated `Context`, so edge-edit's base graph and SDA's automaton settings sit beside their own genome type instead of being threaded through a generic evolver that has no use for either.

**Evolvers never construct genomes.** 
Genome constructors differ per representation and some are fallible, so a generic `Evolver<G>` cannot build a `G`. Dispatch builds the starting population — where representation-specific knowledge already lives — and hands it to `Evolver::new`. Fallible construction then fails at startup rather than being `.expect()`-ed mid-run, and population size has exactly one source of truth: the length of that `Vec`.

**Expression is split from scoring, deliberately.** 
`common::evaluate` expresses the whole population first, then scores the batch in one call. Native objectives parallelise the expression over rayon with no GIL involved; a Python objective overrides the batch hook and crosses the FFI boundary **once per generation** instead of once per individual — the difference between G and G×P crossings.

**Nothing is stored that is already derivable.** 
`SharedEvolutionContext` omits population size, network size, and edge-multiplicity cap: each is knowable from
the population, the genome context, or an expressed `Graph`. A second copy can drift from the first, and nothing would report it.

**Validation happens once, at startup.**
 Genome dimensions and edit-operation weights are checked when their engine types are built, surfacing as a
`PyValueError` before evolution begins. The per-generation path carries no error handling as a result.

## How this affects implementation

Constraints an implementer inherits, each already reflected in the signatures:

- **`Genome::Context: Send + Sync`.** Required because `evaluate` shares one
  `&Context` across rayon workers. Without the bound the documented parallel
  expression does not compile.
- **`evaluate` returns `(Vec<Graph>, Vec<f64>)`,** index-aligned to the
  population. Scoring has to build the graphs anyway, so returning them is free
  and saves re-expressing the winner. It deliberately does *not* pick a best —
  the lower-is-better convention stays with the caller.
- **`GraphEvolver` cannot cache an `EvolutionOutcome<G>`.** The outcome is
  generic; `#[pyclass]` types cannot be. Each dispatch arm must erase the genome
  type before returning, keeping the fitness, the history, the edge list, and the
  genome as a `String` via `Genome::print` — which is what that method is for.
- **Dispatch owes validation the type system cannot express:**
  `init_state < num_states` when building an `SdaContext`; and for a
  caller-supplied base graph, a node-count match plus a check on cap narrowing —
  `Graph::set_edge` *clamps*, so piping a cap-5 graph into a cap-1 run silently
  collapses every weight and the run still looks healthy.
- **Suggested order:** the shared mechanics in `evolver/common.rs` first, since
  everything else calls them; then `SirFitness`, to have a real objective to test
  against; then the generational path end-to-end, which exercises the full
  config → dispatch → evolve → result chain before steady-state or the SDA arm
  are added.

## Also in this PR

Wiring `[genome.operation_weights]` through to the edge-edit genome, and a
complexity pass over the existing code — removing `Genome::copy` (a duplicate of
`Clone`), the duplicated fields on `SharedEvolutionContext`, and a stale README
section describing constructors that no longer exist. The edit-operation mix is
now built and validated once per run and shared across the population behind an
`Arc`, rather than copied onto every individual and recompiled on every mutation.

